### PR TITLE
Implement simple cycle design point solver

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
+use twine_components::thermal::hx::discretized::GivenUaConfig;
 use twine_core::constraint::{
-    Constrained, ConstraintResult, NonNegative, UnitBounds, UnitIntervalLowerOpen,
+    Constrained, ConstraintResult, NonNegative, UnitBounds, UnitInterval, UnitIntervalLowerOpen,
     UnitIntervalUpperOpen,
 };
 use uom::si::{
@@ -50,14 +51,33 @@ impl IsentropicEfficiency {
         Ok(Self(Constrained::new(r)?))
     }
 
-    /// Gets the efficiency as a `Ratio`.
+    /// Returns the efficiency as a `Ratio`.
     #[must_use]
     pub fn as_ratio(&self) -> Ratio {
         *self.0.as_ref()
     }
+
+    /// Returns the efficiency as `Constrained<Ratio, UnitIntervalLowerOpen>`.
+    ///
+    /// Use this for compressor isentropic efficiency.
+    #[must_use]
+    pub fn as_lower_open(&self) -> Constrained<Ratio, UnitIntervalLowerOpen> {
+        self.0
+    }
+
+    /// Returns the efficiency as `Constrained<Ratio, UnitInterval>`.
+    ///
+    /// Use this for turbine isentropic efficiency.
+    /// The widening from (0, 1] to [0, 1] is safe because (0, 1] ⊆ [0, 1].
+    #[must_use]
+    #[allow(clippy::missing_panics_doc)]
+    pub fn as_unit_interval(&self) -> Constrained<Ratio, UnitInterval> {
+        Constrained::new(self.0.into_inner())
+            .expect("UnitIntervalLowerOpen is within UnitInterval bounds")
+    }
 }
 
-/// Thermal–hydraulic parameters for heat exchangers in the cycle.
+/// Configuration for the heat exchanger models.
 #[derive(Debug, Clone, Copy)]
 pub struct HxConfig {
     /// Recuperator parameters.
@@ -70,7 +90,7 @@ pub struct HxConfig {
     pub primary_dp: PressureDrop,
 }
 
-/// Thermal–hydraulic parameters for the recuperator model.
+/// Configuration for the recuperator model.
 #[derive(Debug, Clone, Copy)]
 pub struct RecuperatorConfig {
     /// Overall thermal conductance (`UA`) of the recuperator.
@@ -81,6 +101,9 @@ pub struct RecuperatorConfig {
 
     /// Hot-side (turbine-side) pressure drop.
     pub dp_hot: PressureDrop,
+
+    /// Convergence settings for the recuperator solver.
+    pub convergence: GivenUaConfig,
 }
 
 /// Model for pressure drop across a component.
@@ -97,7 +120,7 @@ pub enum PressureDrop {
 }
 
 impl PressureDrop {
-    /// Construct a fixed pressure drop `Δp`.
+    /// Constructs a fixed pressure drop `Δp`.
     ///
     /// # Errors
     ///
@@ -106,7 +129,7 @@ impl PressureDrop {
         Ok(Self::Absolute(Constrained::new(dp)?))
     }
 
-    /// Construct a fractional pressure drop `f` referenced to inlet pressure.
+    /// Constructs a fractional pressure drop `f` referenced to inlet pressure.
     ///
     /// # Errors
     ///
@@ -115,7 +138,7 @@ impl PressureDrop {
         Ok(Self::Fraction(Constrained::new(f)?))
     }
 
-    /// Calculate outlet pressure given inlet pressure.
+    /// Calculates outlet pressure given inlet pressure.
     ///
     /// For forward flow direction: `p_out = p_in - Δp`
     #[must_use]
@@ -127,7 +150,7 @@ impl PressureDrop {
         }
     }
 
-    /// Calculate inlet pressure given outlet pressure.
+    /// Calculates inlet pressure given outlet pressure.
     ///
     /// For backward flow direction: `p_in = p_out + Δp`
     ///

--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -1,0 +1,150 @@
+use twine_components::{
+    thermal::hx::{
+        arrangement::CounterFlow,
+        discretized::{DiscretizedHx, Inlets, Known, MassFlows, PressureDrops},
+    },
+    turbomachinery::{compressor, turbine},
+};
+use twine_thermo::{
+    capability::{HasEnthalpy, HasEntropy, HasPressure, StateFrom, ThermoModel},
+    units::{SpecificEnthalpy, SpecificEntropy},
+};
+use uom::{
+    ConstZero,
+    si::f64::{Pressure, ThermodynamicTemperature},
+};
+
+use super::{Config, CycleStates, Error, OperatingPoint, Solution};
+
+/// Solve for cycle performance at the design point.
+///
+/// Calculates all thermodynamic states, mass flow rate, component powers,
+/// and thermal efficiency for a simple recuperated Brayton cycle given
+/// operating conditions and hardware configuration.
+///
+/// # Errors
+///
+/// Returns an error on infeasible operating points, thermodynamic model
+/// failures, or component model failures.
+pub fn design_point<Fluid, Model, const N: usize>(
+    operating_point: OperatingPoint,
+    config: &Config,
+    fluid: Fluid,
+    thermo: &Model,
+) -> Result<Solution<Fluid>, Error<Fluid>>
+where
+    Fluid: Clone,
+    Model: ThermoModel<Fluid = Fluid>
+        + HasPressure
+        + HasEnthalpy
+        + HasEntropy
+        + StateFrom<(Fluid, ThermodynamicTemperature, Pressure)>
+        + StateFrom<(Fluid, Pressure, SpecificEnthalpy)>
+        + StateFrom<(Fluid, Pressure, SpecificEntropy)>,
+{
+    // Calculate pressures at all state points.
+    // Work forward from the compressor inlet through the hot side,
+    // and backward from the precooler outlet through the cold side.
+    let p1 = operating_point.p_comp_in;
+    let p2 = operating_point.p_comp_out;
+    let p3 = config.hx.recuperator.dp_cold.outlet_pressure(p2);
+    let p4 = config.hx.primary_dp.outlet_pressure(p3);
+    let p6 = config.hx.precooler_dp.inlet_pressure(p1);
+    let p5 = config.hx.recuperator.dp_hot.inlet_pressure(p6);
+
+    // Validate pressures: turbine inlet must exceed turbine outlet.
+    if p4 <= p5 {
+        return Err(Error::InsufficientPressureRise {
+            rise: p2 - p1,
+            drop: (p2 - p4) + (p5 - p1),
+        });
+    }
+
+    // Calculate known states from the operating point.
+    let s1 = thermo
+        .state_from((fluid.clone(), operating_point.t_comp_in, p1))
+        .map_err(|e| Error::thermo_failed("state_from(compressor inlet)", e))?;
+    let s4 = thermo
+        .state_from((fluid.clone(), operating_point.t_turb_in, p4))
+        .map_err(|e| Error::thermo_failed("state_from(turbine inlet)", e))?;
+
+    // Go through compressor to define state 2.
+    let compressor::CompressionResult {
+        outlet: s2,
+        work: comp_work,
+    } = compressor::isentropic(&s1, p2, config.turbo.eta_comp.as_lower_open(), thermo)?;
+
+    // Go through turbine to define state 5.
+    let turbine::ExpansionResult {
+        outlet: s5,
+        work: turb_work,
+    } = turbine::isentropic(&s4, p5, config.turbo.eta_turb.as_unit_interval(), thermo)?;
+
+    // Calculate net power and required mass flow rate.
+    let w_net = turb_work.quantity() - comp_work.quantity();
+    if w_net <= SpecificEnthalpy::ZERO {
+        return Err(Error::InsufficientTurbineWork { w_net });
+    }
+    let m_dot = operating_point.net_power.into_inner() / w_net;
+
+    // Solve recuperator with given UA to define states 3 and 6.
+    let recup = DiscretizedHx::<CounterFlow, N>::given_ua_same(
+        &Known {
+            inlets: Inlets {
+                top: s2.clone(),
+                bottom: s5.clone(),
+            },
+            m_dot: MassFlows::new_unchecked(m_dot, m_dot),
+            dp: PressureDrops::new_unchecked(p5 - p6, p2 - p3),
+        },
+        config.hx.recuperator.ua,
+        config.hx.recuperator.convergence,
+        thermo,
+    )?;
+    let s3 = recup.top[N - 1].clone();
+    let s6 = recup.bottom[0].clone();
+
+    // Heat rejection from precooler energy balance: q = h6 - h1.
+    let h6 = thermo
+        .enthalpy(&s6)
+        .map_err(|e| Error::thermo_failed("enthalpy(precooler inlet)", e))?;
+    let h1 = thermo
+        .enthalpy(&s1)
+        .map_err(|e| Error::thermo_failed("enthalpy(precooler outlet)", e))?;
+    let q_pc = h6 - h1;
+
+    // Heat addition from PHX energy balance: q = h4 - h3.
+    let h3 = thermo
+        .enthalpy(&s3)
+        .map_err(|e| Error::thermo_failed("enthalpy(phx inlet)", e))?;
+    let h4 = thermo
+        .enthalpy(&s4)
+        .map_err(|e| Error::thermo_failed("enthalpy(phx outlet)", e))?;
+    let q_phx = h4 - h3;
+
+    // Thermal efficiency: net work output / heat input.
+    let eta_thermal = w_net / q_phx;
+
+    // Convert specific quantities to power and heat rates.
+    let w_dot_comp = comp_work.quantity() * m_dot;
+    let w_dot_turb = turb_work.quantity() * m_dot;
+    let q_dot_phx = q_phx * m_dot;
+    let q_dot_pc = q_pc * m_dot;
+
+    Ok(Solution {
+        states: CycleStates {
+            s1,
+            s2,
+            s3,
+            s4,
+            s5,
+            s6,
+        },
+        m_dot,
+        w_dot_comp,
+        w_dot_turb,
+        q_dot_pc,
+        q_dot_phx,
+        eta_thermal,
+    })
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,6 @@ pub enum Error<Fluid> {
 
 impl<Fluid> Error<Fluid> {
     /// Creates a thermo model failure error with context.
-    #[allow(dead_code)]
     pub(crate) fn thermo_failed(
         context: impl Into<String>,
         err: impl StdError + Send + Sync + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod config;
+mod cycle;
 mod error;
 mod operating_point;
 mod solution;
@@ -6,6 +7,7 @@ mod solution;
 pub use config::{
     Config, HxConfig, IsentropicEfficiency, PressureDrop, RecuperatorConfig, TurboConfig,
 };
+pub use cycle::design_point;
 pub use error::Error;
 pub use operating_point::OperatingPoint;
 pub use solution::{CycleStates, Solution};

--- a/tests/simple_design_point.rs
+++ b/tests/simple_design_point.rs
@@ -1,0 +1,107 @@
+use brayton::*;
+
+use twine_components::thermal::hx::discretized::GivenUaConfig;
+use twine_core::constraint::Constrained;
+use twine_thermo::{fluid::CarbonDioxide, model::PerfectGas};
+use uom::si::{
+    f64::{Power, Pressure, Ratio, ThermalConductance, ThermodynamicTemperature},
+    power::megawatt,
+    pressure::kilopascal,
+    ratio::ratio,
+    thermal_conductance::kilowatt_per_kelvin,
+    thermodynamic_temperature::degree_celsius,
+};
+
+/// Create a reasonable baseline configuration for testing.
+fn baseline_config() -> Config {
+    Config {
+        turbo: TurboConfig {
+            eta_comp: IsentropicEfficiency::new(0.89).unwrap(),
+            eta_turb: IsentropicEfficiency::new(0.93).unwrap(),
+        },
+        hx: HxConfig {
+            recuperator: RecuperatorConfig {
+                ua: Constrained::new(ThermalConductance::new::<kilowatt_per_kelvin>(2000.0))
+                    .unwrap(),
+                dp_cold: PressureDrop::fraction(Ratio::new::<ratio>(0.02)).unwrap(),
+                dp_hot: PressureDrop::fraction(Ratio::new::<ratio>(0.02)).unwrap(),
+                convergence: GivenUaConfig::default(),
+            },
+            precooler_dp: PressureDrop::fraction(Ratio::new::<ratio>(0.01)).unwrap(),
+            primary_dp: PressureDrop::fraction(Ratio::new::<ratio>(0.01)).unwrap(),
+        },
+    }
+}
+
+/// Create a reasonable baseline operating point for testing.
+fn baseline_operating_point() -> OperatingPoint {
+    OperatingPoint {
+        t_comp_in: ThermodynamicTemperature::new::<degree_celsius>(50.0),
+        t_turb_in: ThermodynamicTemperature::new::<degree_celsius>(500.0),
+        p_comp_in: Pressure::new::<kilopascal>(100.0),
+        p_comp_out: Pressure::new::<kilopascal>(300.0),
+        net_power: Constrained::new(Power::new::<megawatt>(10.0)).unwrap(),
+    }
+}
+
+#[test]
+fn smoke_test_perfect_gas_co2() {
+    let op = baseline_operating_point();
+    let config = baseline_config();
+    let fluid = CarbonDioxide;
+    let thermo = PerfectGas::new().unwrap();
+
+    let result = design_point::<_, _, 10>(op, &config, fluid, &thermo);
+
+    assert!(result.is_ok());
+    let solution = result.unwrap();
+
+    // Verify basic physical constraints
+    assert!(solution.m_dot.value > 0.0);
+    assert!(solution.w_dot_comp.value > 0.0);
+    assert!(solution.w_dot_turb.value > solution.w_dot_comp.value);
+    assert!(solution.q_dot_phx.value > 0.0);
+    assert!(solution.q_dot_pc.value > 0.0);
+    assert!(solution.eta_thermal.value > 0.0);
+    assert!(solution.eta_thermal.value < 1.0);
+}
+
+#[test]
+fn design_point_insufficient_pressure_rise() {
+    // Low compression ratio
+    let op = OperatingPoint {
+        p_comp_out: Pressure::new::<kilopascal>(105.0),
+        ..baseline_operating_point()
+    };
+
+    let config = baseline_config();
+    let thermo = PerfectGas::new().unwrap();
+
+    let result = design_point::<_, _, 10>(op, &config, CarbonDioxide, &thermo);
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        Error::InsufficientPressureRise { .. }
+    ));
+}
+
+#[test]
+fn design_point_insufficient_turbine_work() {
+    // Turbine inlet temperature too low relative to compressor inlet
+    let op = OperatingPoint {
+        t_turb_in: ThermodynamicTemperature::new::<degree_celsius>(250.0),
+        ..baseline_operating_point()
+    };
+
+    let config = baseline_config();
+    let thermo = PerfectGas::new().unwrap();
+
+    let result = design_point::<_, _, 10>(op, &config, CarbonDioxide, &thermo);
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        Error::InsufficientTurbineWork { .. }
+    ));
+}


### PR DESCRIPTION
## Summary

- Add `design_point` function that calculates thermodynamic states, mass flow rate, component powers, and thermal efficiency for a simple recuperated Brayton cycle.
- Add `as_lower_open()` and `as_unit_interval()` methods to `IsentropicEfficiency` for type-safe use with compressor and turbine models.
- Expose recuperator convergence settings via `GivenUaConfig`.
- Add integration tests for design point solver including error cases.

Resolves #2