### PR TITLE
Compile facade to WASM via wasm-bindgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/pkg
 /.planning

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,10 +22,35 @@ name = "brayton"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "serde",
+ "serde-wasm-bindgen",
  "thiserror",
  "twine-core",
  "twine-models",
  "uom",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -36,6 +61,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "proc-macro2"
@@ -56,10 +87,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.114"
+name = "rustversion"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -123,9 +201,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uom"
@@ -135,4 +213,49 @@ checksum = "ffd36e5350a65d112584053ee91843955826bf9e56ec0d1351214e01f6d7cd9c"
 dependencies = [
  "num-traits",
  "typenum",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,21 @@ name = "brayton"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+wasm = ["dep:wasm-bindgen", "dep:serde", "dep:serde-wasm-bindgen"]
+
 [dependencies]
 twine-models = "0.1"
 twine-core = "0.5"
 uom = "0.36"
 thiserror = "2.0.16"
+wasm-bindgen = { version = "0.2", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -1,0 +1,27 @@
+# Brayton WASM Smoke Test
+
+A minimal HTML test page that calls the `design_point` function compiled to WebAssembly and logs the result.
+
+## Prerequisites
+
+- [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/)
+- The `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
+
+## Build
+
+From the repo root:
+
+```bash
+wasm-pack build --target web --features wasm
+```
+
+Output goes to `pkg/`.
+
+## Serve
+
+```bash
+cd examples/wasm
+python3 -m http.server 8080
+```
+
+Open [http://localhost:8080](http://localhost:8080). The page calls `design_point` with baseline inputs and renders the result as JSON. Check the browser console for any errors.

--- a/examples/wasm/index.html
+++ b/examples/wasm/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head><title>Brayton WASM Test</title></head>
+<body>
+  <h1>Brayton Cycle — WASM Smoke Test</h1>
+  <pre id="output">Running...</pre>
+  <script type="module">
+    import init, { design_point } from '../../pkg/brayton.js';
+
+    async function run() {
+      await init();
+      const result = design_point({
+        compressor_inlet_temp_c: 50.0,
+        turbine_inlet_temp_c: 500.0,
+        compressor_inlet_pressure_kpa: 100.0,
+        compressor_outlet_pressure_kpa: 300.0,
+        net_power_kw: 10000.0,
+        compressor_efficiency: 0.89,
+        turbine_efficiency: 0.93,
+        recuperator_ua_kw_per_k: 2000.0,
+        recuperator_segments: 10,
+        recuperator_dp_cold_fraction: 0.02,
+        recuperator_dp_hot_fraction: 0.02,
+        precooler_dp_fraction: 0.01,
+        primary_hx_dp_fraction: 0.01,
+      });
+      document.getElementById('output').textContent =
+        JSON.stringify(result, null, 2);
+    }
+
+    run().catch(e => {
+      document.getElementById('output').textContent = 'Error: ' + e;
+    });
+  </script>
+</body>
+</html>

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -26,6 +26,7 @@ use crate::{
 /// All temperatures in °C, pressures in kPa, power in kW,
 /// thermal conductance in kW/K, efficiencies and pressure drop
 /// fractions as dimensionless ratios (0–1).
+#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
 pub struct DesignPointInput {
     // Operating point
     /// Compressor inlet temperature in degrees Celsius.
@@ -75,6 +76,7 @@ pub struct DesignPointInput {
 
 /// Thermodynamic performance output for a design-point calculation.
 #[derive(Debug)]
+#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
 pub struct DesignPointOutput {
     /// Cycle mass flow rate in kilograms per second.
     pub mass_flow_kg_per_s: f64,
@@ -111,6 +113,7 @@ pub struct DesignPointOutput {
 
 /// Thermodynamic state at a single cycle point.
 #[derive(Debug)]
+#[cfg_attr(feature = "wasm", derive(serde::Serialize, serde::Deserialize))]
 pub struct StatePoint {
     /// Temperature in degrees Celsius.
     pub temperature_c: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ pub mod facade;
 mod operating_point;
 mod solution;
 
+#[cfg(feature = "wasm")]
+mod wasm;
+
 pub use config::{
     Config, HxConfig, InvalidPressureDrop, IsentropicEfficiency, PressureDrop, RecuperatorConfig,
     TurboConfig,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,14 @@
+use wasm_bindgen::prelude::*;
+
+use crate::facade;
+
+/// Run a simple recuperated Brayton cycle design-point calculation from JS.
+///
+/// Accepts a plain JS object matching [`facade::DesignPointInput`] and returns
+/// a plain JS object matching [`facade::DesignPointOutput`].
+#[wasm_bindgen]
+pub fn design_point(input: JsValue) -> Result<JsValue, JsError> {
+    let input: facade::DesignPointInput = serde_wasm_bindgen::from_value(input)?;
+    let output = facade::design_point(&input).map_err(|e| JsError::new(&e))?;
+    serde_wasm_bindgen::to_value(&output).map_err(|e| JsError::new(&e.to_string()))
+}


### PR DESCRIPTION
Compiles the facade to WebAssembly via `wasm-bindgen`. Closes #23.

Adds a `wasm` feature gate with `wasm-bindgen`, `serde`, and `serde-wasm-bindgen` as optional dependencies. The thin `src/wasm.rs` wrapper deserializes `DesignPointInput` from a JS object, calls the facade, and serializes the output back.

Facade structs get conditional `#[derive(Serialize, Deserialize)]` behind the feature. Input and output cross the boundary as plain JS objects — `[StatePoint; 6]` wouldn't work with `wasm-bindgen` directly, so serde is the right approach.

Includes a smoke test HTML page in `examples/wasm/` with build and serve instructions.

### Build

```bash
wasm-pack build --target web --features wasm
```
