### PR TITLE
Add interactive web dashboard

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,182 @@
+import init, { design_point } from '../pkg/brayton.js';
+import { createCycleChart } from './cycle-chart.js';
+
+const STATE_LABELS = [
+  'Compressor in',
+  'Compressor out',
+  'Recup cold out',
+  'Turbine in',
+  'Turbine out',
+  'Recup hot out',
+];
+
+const INPUT_IDS = [
+  'compressor_inlet_temp_c',
+  'turbine_inlet_temp_c',
+  'compressor_inlet_pressure_kpa',
+  'compressor_outlet_pressure_kpa',
+  'net_power_kw',
+  'compressor_efficiency_pct',
+  'turbine_efficiency_pct',
+  'recuperator_ua_kw_per_k',
+  'recuperator_segments',
+  'recuperator_dp_cold_pct',
+  'recuperator_dp_hot_pct',
+  'precooler_dp_pct',
+  'primary_hx_dp_pct',
+];
+
+let tsChart = null;
+let phChart = null;
+
+// Fields where the UI shows percent but the facade expects a 0–1 fraction.
+// Fields where the UI shows percent but the facade expects a 0–1 value.
+const PCT_FIELDS = [
+  'compressor_efficiency_pct',
+  'turbine_efficiency_pct',
+  'recuperator_dp_cold_pct',
+  'recuperator_dp_hot_pct',
+  'precooler_dp_pct',
+  'primary_hx_dp_pct',
+];
+
+// Map from UI element IDs to facade field names (only where they differ).
+const FIELD_MAP = {
+  'compressor_efficiency_pct': 'compressor_efficiency',
+  'turbine_efficiency_pct': 'turbine_efficiency',
+  'recuperator_dp_cold_pct': 'recuperator_dp_cold_fraction',
+  'recuperator_dp_hot_pct': 'recuperator_dp_hot_fraction',
+  'precooler_dp_pct': 'precooler_dp_fraction',
+  'primary_hx_dp_pct': 'primary_hx_dp_fraction',
+};
+
+function readInputs() {
+  const obj = {};
+  for (const id of INPUT_IDS) {
+    const el = document.getElementById(id);
+    const val = id === 'recuperator_segments'
+      ? parseInt(el.value, 10)
+      : parseFloat(el.value);
+    if (isNaN(val)) return null;
+
+    const key = FIELD_MAP[id] || id;
+    obj[key] = PCT_FIELDS.includes(id) ? val / 100 : val;
+  }
+  return obj;
+}
+
+function fmt(v, decimals = 2) {
+  return v.toFixed(decimals);
+}
+
+function renderScalars(r) {
+  document.getElementById('r-mass-flow').textContent = fmt(r.mass_flow_kg_per_s, 2);
+  document.getElementById('r-comp-power').textContent = fmt(r.compressor_power_kw, 1);
+  document.getElementById('r-turb-power').textContent = fmt(r.turbine_power_kw, 1);
+  document.getElementById('r-net-power').textContent = fmt(r.net_power_kw, 1);
+  document.getElementById('r-heat-in').textContent = fmt(r.heat_input_kw, 1);
+  document.getElementById('r-heat-rej').textContent = fmt(r.heat_rejection_kw, 1);
+  document.getElementById('r-eta').textContent = fmt(r.thermal_efficiency * 100, 2);
+}
+
+function renderStates(states) {
+  const tbody = document.getElementById('state-tbody');
+  tbody.innerHTML = '';
+  states.forEach((s, i) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${i + 1}</td>
+      <td>${STATE_LABELS[i]}</td>
+      <td>${fmt(s.temperature_c, 1)}</td>
+      <td>${fmt(s.pressure_kpa, 1)}</td>
+      <td>${fmt(s.density_kg_per_m3, 3)}</td>
+      <td>${fmt(s.enthalpy_kj_per_kg, 1)}</td>
+      <td>${fmt(s.entropy_kj_per_kg_k, 4)}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function toChartPoints(states, xKey, yKey) {
+  return states.map((s, i) => ({
+    x: s[xKey],
+    y: s[yKey],
+    label: String(i + 1),
+  }));
+}
+
+function renderCharts(states) {
+  const tsPoints = toChartPoints(states, 'entropy_kj_per_kg_k', 'temperature_c');
+  const phPoints = toChartPoints(states, 'enthalpy_kj_per_kg', 'pressure_kpa');
+
+  if (!tsChart) {
+    tsChart = createCycleChart(document.getElementById('chart-ts'), {
+      title: 'T–s Diagram',
+      xLabel: 's (kJ/kg·K)',
+      yLabel: 'T (°C)',
+    });
+  }
+  tsChart.update(tsPoints);
+
+  if (!phChart) {
+    phChart = createCycleChart(document.getElementById('chart-ph'), {
+      title: 'P–h Diagram',
+      xLabel: 'h (kJ/kg)',
+      yLabel: 'P (kPa)',
+    });
+  }
+  phChart.update(phPoints);
+}
+
+function showError(msg) {
+  const el = document.getElementById('error');
+  el.textContent = msg;
+  el.hidden = false;
+  document.getElementById('results-content').style.opacity = '0.3';
+}
+
+function clearError() {
+  document.getElementById('error').hidden = true;
+  document.getElementById('results-content').style.opacity = '1';
+}
+
+function calculate() {
+  const input = readInputs();
+  if (!input) {
+    showError('Some inputs are empty or invalid.');
+    return;
+  }
+
+  try {
+    const result = design_point(input);
+    clearError();
+    renderScalars(result);
+    renderStates(result.states);
+    renderCharts(result.states);
+  } catch (e) {
+    showError(e.message || String(e));
+  }
+}
+
+let debounceTimer = null;
+
+function onInputChange() {
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(calculate, 300);
+}
+
+async function main() {
+  await init();
+
+  for (const id of INPUT_IDS) {
+    const el = document.getElementById(id);
+    el.addEventListener('input', onInputChange);
+  }
+
+  // Initial calculation with defaults.
+  calculate();
+}
+
+main().catch(e => {
+  showError('Failed to initialize WASM: ' + (e.message || e));
+});

--- a/web/cycle-chart.js
+++ b/web/cycle-chart.js
@@ -1,0 +1,199 @@
+/**
+ * Lightweight cycle diagram renderer using Canvas 2D.
+ *
+ * API:
+ *   const chart = createCycleChart(container, { title, xLabel, yLabel })
+ *   chart.update(points)  // points = [{ x, y, label }, ...]
+ *
+ * Points are drawn connected in order, with the last point connecting
+ * back to the first (closing the cycle). Each point gets a label.
+ *
+ * To swap rendering (e.g., to a charting library), replace this file
+ * and keep the same create/update interface.
+ */
+
+const PADDING = { top: 40, right: 30, bottom: 50, left: 65 };
+const POINT_RADIUS = 4;
+const COLORS = {
+  line: '#2563eb',
+  fill: 'rgba(37, 99, 235, 0.06)',
+  point: '#2563eb',
+  label: '#1a1a1a',
+  axis: '#888',
+  grid: '#e5e5e5',
+  title: '#333',
+};
+
+export function createCycleChart(container, { title, xLabel, yLabel }) {
+  const canvas = document.createElement('canvas');
+  const dpr = window.devicePixelRatio || 1;
+  container.appendChild(canvas);
+
+  const ctx = canvas.getContext('2d');
+  let currentPoints = null;
+
+  function resize() {
+    const rect = container.getBoundingClientRect();
+    const w = Math.floor(rect.width) || 400;
+    const h = 300;
+    canvas.style.width = w + 'px';
+    canvas.style.height = h + 'px';
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    if (currentPoints) draw(currentPoints, w, h);
+  }
+
+  function niceRange(min, max) {
+    if (min === max) {
+      min -= 1;
+      max += 1;
+    }
+    const range = max - min;
+    const margin = range * 0.1;
+    return [min - margin, max + margin];
+  }
+
+  function niceStep(range) {
+    const rough = range / 5;
+    const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+    const norm = rough / mag;
+    let step;
+    if (norm <= 1.5) step = 1;
+    else if (norm <= 3.5) step = 2;
+    else if (norm <= 7.5) step = 5;
+    else step = 10;
+    return step * mag;
+  }
+
+  function draw(points, w, h) {
+    ctx.clearRect(0, 0, w, h);
+
+    const plotW = w - PADDING.left - PADDING.right;
+    const plotH = h - PADDING.top - PADDING.bottom;
+
+    // Compute ranges from data.
+    const xs = points.map(p => p.x);
+    const ys = points.map(p => p.y);
+    const [xMin, xMax] = niceRange(Math.min(...xs), Math.max(...xs));
+    const [yMin, yMax] = niceRange(Math.min(...ys), Math.max(...ys));
+
+    function toCanvasX(v) { return PADDING.left + ((v - xMin) / (xMax - xMin)) * plotW; }
+    function toCanvasY(v) { return PADDING.top + plotH - ((v - yMin) / (yMax - yMin)) * plotH; }
+
+    // Grid and axes.
+    ctx.strokeStyle = COLORS.grid;
+    ctx.lineWidth = 0.5;
+    ctx.fillStyle = COLORS.axis;
+    ctx.font = '11px -apple-system, sans-serif';
+    ctx.textAlign = 'center';
+
+    const xStep = niceStep(xMax - xMin);
+    const xStart = Math.ceil(xMin / xStep) * xStep;
+    for (let v = xStart; v <= xMax; v += xStep) {
+      const cx = toCanvasX(v);
+      ctx.beginPath();
+      ctx.moveTo(cx, PADDING.top);
+      ctx.lineTo(cx, PADDING.top + plotH);
+      ctx.stroke();
+      ctx.fillText(formatTick(v), cx, PADDING.top + plotH + 16);
+    }
+
+    ctx.textAlign = 'right';
+    const yStep = niceStep(yMax - yMin);
+    const yStart = Math.ceil(yMin / yStep) * yStep;
+    for (let v = yStart; v <= yMax; v += yStep) {
+      const cy = toCanvasY(v);
+      ctx.beginPath();
+      ctx.moveTo(PADDING.left, cy);
+      ctx.lineTo(PADDING.left + plotW, cy);
+      ctx.stroke();
+      ctx.fillText(formatTick(v), PADDING.left - 8, cy + 4);
+    }
+
+    // Plot border.
+    ctx.strokeStyle = COLORS.axis;
+    ctx.lineWidth = 1;
+    ctx.strokeRect(PADDING.left, PADDING.top, plotW, plotH);
+
+    // Filled cycle polygon.
+    ctx.beginPath();
+    ctx.moveTo(toCanvasX(points[0].x), toCanvasY(points[0].y));
+    for (let i = 1; i < points.length; i++) {
+      ctx.lineTo(toCanvasX(points[i].x), toCanvasY(points[i].y));
+    }
+    ctx.closePath();
+    ctx.fillStyle = COLORS.fill;
+    ctx.fill();
+
+    // Cycle line.
+    ctx.beginPath();
+    ctx.moveTo(toCanvasX(points[0].x), toCanvasY(points[0].y));
+    for (let i = 1; i < points.length; i++) {
+      ctx.lineTo(toCanvasX(points[i].x), toCanvasY(points[i].y));
+    }
+    ctx.closePath();
+    ctx.strokeStyle = COLORS.line;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // Points and labels.
+    for (const p of points) {
+      const cx = toCanvasX(p.x);
+      const cy = toCanvasY(p.y);
+
+      ctx.beginPath();
+      ctx.arc(cx, cy, POINT_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = COLORS.point;
+      ctx.fill();
+
+      if (p.label) {
+        ctx.fillStyle = COLORS.label;
+        ctx.font = 'bold 11px -apple-system, sans-serif';
+        ctx.textAlign = 'left';
+        ctx.fillText(p.label, cx + 7, cy - 7);
+      }
+    }
+
+    // Title.
+    ctx.fillStyle = COLORS.title;
+    ctx.font = 'bold 13px -apple-system, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(title, w / 2, 20);
+
+    // Axis labels.
+    ctx.fillStyle = COLORS.axis;
+    ctx.font = '12px -apple-system, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(xLabel, PADDING.left + plotW / 2, h - 6);
+
+    ctx.save();
+    ctx.translate(14, PADDING.top + plotH / 2);
+    ctx.rotate(-Math.PI / 2);
+    ctx.fillText(yLabel, 0, 0);
+    ctx.restore();
+  }
+
+  function formatTick(v) {
+    if (Math.abs(v) >= 1000) return v.toFixed(0);
+    if (Math.abs(v) >= 1) return v.toFixed(1);
+    return v.toFixed(3);
+  }
+
+  function update(points) {
+    currentPoints = points;
+    const rect = container.getBoundingClientRect();
+    const w = Math.floor(rect.width) || 400;
+    const h = 300;
+    canvas.style.width = w + 'px';
+    canvas.style.height = h + 'px';
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    draw(points, w, h);
+  }
+
+  window.addEventListener('resize', resize);
+
+  return { update };
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Brayton Cycle Design Point</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Brayton Cycle — Design Point</h1>
+    <p class="subtitle">Simple recuperated sCO₂ cycle · PerfectGas model · runs in your browser via WASM</p>
+  </header>
+
+  <main>
+    <section class="inputs">
+      <h2>Inputs</h2>
+
+      <fieldset>
+        <legend>Operating Point</legend>
+        <label>Compressor inlet temperature (°C)
+          <input type="number" id="compressor_inlet_temp_c" value="50" step="1">
+        </label>
+        <label>Turbine inlet temperature (°C)
+          <input type="number" id="turbine_inlet_temp_c" value="500" step="1">
+        </label>
+        <label>Compressor inlet pressure (kPa)
+          <input type="number" id="compressor_inlet_pressure_kpa" value="100" step="10">
+        </label>
+        <label>Compressor outlet pressure (kPa)
+          <input type="number" id="compressor_outlet_pressure_kpa" value="300" step="10">
+        </label>
+        <label>Net power (kW)
+          <input type="number" id="net_power_kw" value="10000" step="100">
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Turbomachinery</legend>
+        <label>Compressor efficiency (%)
+          <input type="number" id="compressor_efficiency_pct" value="89" step="1" min="1" max="100">
+        </label>
+        <label>Turbine efficiency (%)
+          <input type="number" id="turbine_efficiency_pct" value="93" step="1" min="1" max="100">
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Recuperator</legend>
+        <label>UA (kW/K)
+          <input type="number" id="recuperator_ua_kw_per_k" value="2000" step="100">
+        </label>
+        <label>Segments
+          <select id="recuperator_segments">
+            <option value="1">1</option>
+            <option value="5">5</option>
+            <option value="10" selected>10</option>
+            <option value="20">20</option>
+            <option value="50">50</option>
+          </select>
+        </label>
+        <label>Cold-side ΔP (%)
+          <input type="number" id="recuperator_dp_cold_pct" value="2" step="0.5" min="0" max="50">
+        </label>
+        <label>Hot-side ΔP (%)
+          <input type="number" id="recuperator_dp_hot_pct" value="2" step="0.5" min="0" max="50">
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Pressure Drops</legend>
+        <label>Precooler ΔP (%)
+          <input type="number" id="precooler_dp_pct" value="1" step="0.5" min="0" max="50">
+        </label>
+        <label>Primary HX ΔP (%)
+          <input type="number" id="primary_hx_dp_pct" value="1" step="0.5" min="0" max="50">
+        </label>
+      </fieldset>
+    </section>
+
+    <section class="results">
+      <h2>Results</h2>
+
+      <div id="error" class="error" hidden></div>
+
+      <div id="results-content">
+        <div class="scalars">
+          <h3>Performance</h3>
+          <table id="scalar-table">
+            <tbody>
+              <tr><td>Mass flow rate</td><td id="r-mass-flow">—</td><td>kg/s</td></tr>
+              <tr><td>Compressor power</td><td id="r-comp-power">—</td><td>kW</td></tr>
+              <tr><td>Turbine power</td><td id="r-turb-power">—</td><td>kW</td></tr>
+              <tr><td>Net power</td><td id="r-net-power">—</td><td>kW</td></tr>
+              <tr><td>Heat input</td><td id="r-heat-in">—</td><td>kW</td></tr>
+              <tr><td>Heat rejection</td><td id="r-heat-rej">—</td><td>kW</td></tr>
+              <tr><td>Thermal efficiency</td><td id="r-eta">—</td><td>%</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="states">
+          <h3>State Points</h3>
+          <table id="state-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Location</th>
+                <th>T (°C)</th>
+                <th>P (kPa)</th>
+                <th>ρ (kg/m³)</th>
+                <th>h (kJ/kg)</th>
+                <th>s (kJ/kg·K)</th>
+              </tr>
+            </thead>
+            <tbody id="state-tbody"></tbody>
+          </table>
+        </div>
+
+        <div class="charts">
+          <h3>Cycle Diagrams</h3>
+          <div class="chart-row">
+            <div class="chart-container">
+              <div id="chart-ts"></div>
+            </div>
+            <div class="chart-container">
+              <div id="chart-ph"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,175 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #f5f5f5;
+  line-height: 1.5;
+}
+
+header {
+  padding: 1.5rem 2rem 1rem;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+}
+
+header h1 {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  color: #666;
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+main {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 1px;
+  background: #ddd;
+  min-height: calc(100vh - 80px);
+}
+
+.inputs, .results {
+  background: #fff;
+  padding: 1.5rem;
+}
+
+.inputs h2, .results h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+fieldset {
+  border: none;
+  margin-bottom: 1.25rem;
+}
+
+legend {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #444;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+input[type="number"] {
+  display: block;
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  margin-top: 0.15rem;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: 0.9rem;
+  font-family: "SF Mono", "Fira Code", monospace;
+}
+
+input[type="number"]:focus,
+select:focus {
+  outline: none;
+  border-color: #4a9eff;
+  box-shadow: 0 0 0 2px rgba(74, 158, 255, 0.15);
+}
+
+select {
+  display: block;
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  margin-top: 0.15rem;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: 0.9rem;
+  font-family: "SF Mono", "Fira Code", monospace;
+  background: #fff;
+}
+
+/* Results */
+
+.scalars, .states, .charts {
+  margin-bottom: 1.5rem;
+}
+
+h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: #333;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.35rem 0.75rem;
+  border-bottom: 1px solid #eee;
+}
+
+th {
+  font-weight: 600;
+  color: #444;
+  background: #fafafa;
+}
+
+#scalar-table td:nth-child(2) {
+  font-family: "SF Mono", "Fira Code", monospace;
+  text-align: right;
+}
+
+#scalar-table td:nth-child(3) {
+  color: #888;
+  font-size: 0.8rem;
+  width: 60px;
+}
+
+#state-table td {
+  font-family: "SF Mono", "Fira Code", monospace;
+  text-align: right;
+}
+
+#state-table td:first-child,
+#state-table td:nth-child(2) {
+  font-family: inherit;
+  text-align: left;
+}
+
+.error {
+  background: #fff0f0;
+  border: 1px solid #ffcccc;
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
+  color: #cc0000;
+  font-size: 0.85rem;
+  margin-bottom: 1rem;
+}
+
+/* Charts */
+
+.chart-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.chart-container {
+  min-height: 300px;
+}


### PR DESCRIPTION
Interactive single-page dashboard for the simple cycle design point solver. Closes #25.

### UX

Two-panel layout: inputs on the left, results on the right. All 14 input fields have sensible defaults (the baseline test case). Results recalculate live on every input change — no "Calculate" button. Efficiencies and pressure drops are shown as percentages in the UI and converted to fractions before passing to the WASM facade.

### Results

- Scalar performance table (mass flow, powers, efficiency)
- State points table (T, P, ρ, h, s at all 6 cycle points)
- T-s and P-h cycle diagrams

### Charting

Hand-rolled Canvas 2D renderer rather than a charting library. uPlot (our preferred library for future parametric sweeps) requires monotonically increasing x-values, which cycle diagrams violate — entropy and enthalpy go back and forth around the loop. The chart renderer is encapsulated behind a `createCycleChart`/`update` interface in `cycle-chart.js` so we can swap implementations later.

### Tech

Vanilla HTML/CSS/JS. No framework, no build step beyond `wasm-pack`. The WASM module loads via native ES module import.
