### PR TITLE
Add GitHub Pages deployment and README

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Deploy Dashboard
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        run: wasm-pack build --target web --features wasm
+
+      - name: Assemble site
+        run: |
+          mkdir -p _site/pkg
+          cp web/* _site/
+          cp pkg/brayton.js pkg/brayton_bg.wasm _site/pkg/
+
+      - name: Fix import path
+        run: sed -i 's|\.\./pkg/|pkg/|g' _site/app.js
+
+      - uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# brayton
+# Brayton Cycle Models for Supercritical CO₂
+
+Brayton cycle models for sCO₂ power cycles, built on [Twine](https://github.com/isentropic-dev/twine-models).
+
+**[Try the interactive dashboard →](https://isentropic-dev.github.io/brayton/)**
+
+This project recreates the design-point and off-design sCO₂ cycle models from [this thesis](https://github.com/isentropic-dev/brayton/blob/main/docs/dyreby_thesis.pdf) and makes them available as:
+
+- A Rust crate
+- A browser-based interactive dashboard
+- A Python package
+
+## What's here now
+
+The simple recuperated cycle design-point model is working, with three delivery layers:
+
+- **Rust crate** — generic solver with CoolProp/RefProp support via [twine-models](https://github.com/isentropic-dev/twine-models), plus a plain-data facade for FFI consumers
+- **Web dashboard** — interactive, runs entirely in your browser via WASM
+- **Python package** — pip installable via PyO3 with CoolProp support (PR open, PyPI publishing coming soon)
+
+## What's coming
+
+This is active work — expect daily changes over the next few days.
+
+- **Real-gas thermodynamic models** — CoolProp/RefProp integration via Twine, and a Rust port of FIT, which is a table-based interpolation over Helmholtz free energy for fast, accurate, and smooth fluid property calculations
+- **Recompression cycle** design-point model
+- **Off-design models** for both simple and recompression configurations
+- **Parametric studies** in the dashboard
+
+## Development
+
+```bash
+# Run tests
+cargo test
+
+# Build WASM
+wasm-pack build --target web --features wasm
+
+# Serve the dashboard locally
+python3 -m http.server 8080 --directory web
+# Open http://localhost:8080
+
+# Build Python package
+python -m venv .venv && source .venv/bin/activate
+pip install maturin
+maturin develop --features python
+```


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds WASM and deploys the dashboard to GitHub Pages, plus a README that describes the project and links to the live dashboard.

**Note:** GitHub Pages needs to be enabled in the repo settings → Pages → Source: "GitHub Actions" for the deployment to work.

The workflow assembles the site by copying `web/*` and the WASM build output into `_site/`, fixing the import path from `../pkg/` to `pkg/` so the flat directory structure works.
