### PR TITLE
Fix WASM import path in Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
           cp pkg/brayton.js pkg/brayton_bg.wasm _site/pkg/
 
       - name: Fix import path
-        run: sed -i 's|\.\./pkg/|pkg/|g' _site/app.js
+        run: sed -i 's|\.\./pkg/|./pkg/|g' _site/app.js
 
       - uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
Fix the WASM import path in the Pages deployment workflow.

The sed replacement produced a bare specifier (`'pkg/brayton.js'`) which browsers reject as a module import. Changed to a relative path (`'./pkg/brayton.js'`).
