### PR TITLE
Fix local dashboard serve instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,10 @@ This is active work — expect daily changes over the next few days.
 # Run tests
 cargo test
 
-# Build WASM
+# Build and serve the dashboard locally
 wasm-pack build --target web --features wasm
-
-# Serve the dashboard locally
-python3 -m http.server 8080 --directory web
-# Open http://localhost:8080
+python3 -m http.server 8080
+# Open http://localhost:8080/web/
 
 # Build Python package
 python -m venv .venv && source .venv/bin/activate


### PR DESCRIPTION
Fix local dashboard serve instructions. The `--directory web` flag doesn't work because `app.js` imports from `../pkg/`, which is outside the `web/` directory. Serve from the repo root instead.
