### PR TITLE
Make dashboard responsive

### DIFF
--- a/web/cycle-chart.js
+++ b/web/cycle-chart.js
@@ -12,6 +12,8 @@
  * and keep the same create/update interface.
  */
 
+const CHART_WIDTH = 360;
+const CHART_HEIGHT = 280;
 const PADDING = { top: 40, right: 30, bottom: 50, left: 65 };
 const POINT_RADIUS = 4;
 const COLORS = {
@@ -32,17 +34,6 @@ export function createCycleChart(container, { title, xLabel, yLabel }) {
   const ctx = canvas.getContext('2d');
   let currentPoints = null;
 
-  function resize() {
-    const rect = container.getBoundingClientRect();
-    const w = Math.floor(rect.width) || 400;
-    const h = 300;
-    canvas.style.width = w + 'px';
-    canvas.style.height = h + 'px';
-    canvas.width = w * dpr;
-    canvas.height = h * dpr;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    if (currentPoints) draw(currentPoints, w, h);
-  }
 
   function niceRange(min, max) {
     if (min === max) {
@@ -182,18 +173,13 @@ export function createCycleChart(container, { title, xLabel, yLabel }) {
 
   function update(points) {
     currentPoints = points;
-    const rect = container.getBoundingClientRect();
-    const w = Math.floor(rect.width) || 400;
-    const h = 300;
-    canvas.style.width = w + 'px';
-    canvas.style.height = h + 'px';
-    canvas.width = w * dpr;
-    canvas.height = h * dpr;
+    canvas.style.width = CHART_WIDTH + 'px';
+    canvas.style.height = CHART_HEIGHT + 'px';
+    canvas.width = CHART_WIDTH * dpr;
+    canvas.height = CHART_HEIGHT * dpr;
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    draw(points, w, h);
+    draw(points, CHART_WIDTH, CHART_HEIGHT);
   }
-
-  window.addEventListener('resize', resize);
 
   return { update };
 }

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <h1>Brayton Cycle — Design Point</h1>
-    <p class="subtitle">Simple recuperated sCO₂ cycle · runs in your browser via WASM · ideal gas properties for now, real gas models coming soon</p>
+    <p class="subtitle"><span>Simple recuperated sCO₂ cycle</span><span>runs in your browser via WASM</span><span>ideal gas properties for now, real gas models coming soon</span></p>
   </header>
 
   <main>

--- a/web/style.css
+++ b/web/style.css
@@ -27,11 +27,22 @@ header h1 {
   color: #666;
   font-size: 0.85rem;
   margin-top: 0.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 0.5ch;
+}
+
+.subtitle span {
+  white-space: nowrap;
+}
+
+.subtitle span + span::before {
+  content: '· ';
 }
 
 main {
   display: grid;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: 280px 1fr;
   gap: 1px;
   background: #ddd;
   min-height: calc(100vh - 80px);
@@ -122,7 +133,7 @@ table {
 }
 
 #state-table {
-  width: 100%;
+  width: max(100%, 600px);
 }
 
 th, td {
@@ -183,5 +194,55 @@ th {
 }
 
 .chart-container {
-  min-height: 300px;
+  min-height: 0;
+}
+
+/* Responsive: stack layout on narrow screens */
+
+@media (max-width: 640px) {
+  body {
+    overflow-x: hidden;
+  }
+
+  main {
+    display: block;
+    background: #fff;
+  }
+
+  .inputs {
+    border-bottom: 1px solid #ddd;
+  }
+
+  .inputs label,
+  .inputs input,
+  .inputs select {
+    max-width: 300px;
+  }
+
+  .results > * {
+    max-width: none;
+  }
+
+  #scalar-table {
+    width: 100%;
+  }
+
+  .chart-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .states {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
+@media (max-width: 480px) {
+  header {
+    padding: 1rem;
+  }
+
+  .inputs, .results {
+    padding: 1rem;
+  }
 }


### PR DESCRIPTION
Make the dashboard usable on smaller screens.

- Below 640px: inputs stack above results, charts go single column, state table scrolls horizontally
- Below 480px: tighter padding
- Fixed-size charts (360×280) — no more resize glitches
- Subtitle wraps cleanly at segment boundaries (dots lead the next line, not trail the previous)
- Inputs column narrowed to 280px
- State table has 600px minimum width so columns aren't cramped

Closes #32
