### PR TITLE
Fix swapped recuperator pressure drops in design point

### DIFF
--- a/src/cycle.rs
+++ b/src/cycle.rs
@@ -105,7 +105,8 @@ where
             bottom: s5.clone(),
         },
         mass_flows: MassFlows::new_unchecked(m_dot, m_dot),
-        pressure_drops: PressureDrops::new_unchecked(p5 - p6, p2 - p3),
+        // top = cold side, bottom = hot side
+        pressure_drops: PressureDrops::new_unchecked(p2 - p3, p5 - p6),
         ua: config.hx.recuperator.ua,
     })?;
     let s3 = recup_result.top_outlet;

--- a/src/facade.rs
+++ b/src/facade.rs
@@ -305,6 +305,42 @@ mod tests {
         }
     }
 
+    /// Pressures must decrease monotonically along each flow path:
+    /// high side (P2 > P3 > P4) and low side (P5 > P6 > P1).
+    #[test]
+    fn pressures_decrease_along_flow_path() {
+        let out = design_point(&baseline_input()).unwrap();
+        let [s1, s2, s3, s4, s5, s6] = &out.states;
+
+        // High-pressure side: compressor outlet → recuperator cold → PHX → turbine inlet.
+        assert!(
+            s2.pressure_kpa > s3.pressure_kpa,
+            "P2 ({}) must exceed P3 ({})",
+            s2.pressure_kpa,
+            s3.pressure_kpa,
+        );
+        assert!(
+            s3.pressure_kpa > s4.pressure_kpa,
+            "P3 ({}) must exceed P4 ({})",
+            s3.pressure_kpa,
+            s4.pressure_kpa,
+        );
+
+        // Low-pressure side: turbine outlet → recuperator hot → precooler → compressor inlet.
+        assert!(
+            s5.pressure_kpa > s6.pressure_kpa,
+            "P5 ({}) must exceed P6 ({})",
+            s5.pressure_kpa,
+            s6.pressure_kpa,
+        );
+        assert!(
+            s6.pressure_kpa > s1.pressure_kpa,
+            "P6 ({}) must exceed P1 ({})",
+            s6.pressure_kpa,
+            s1.pressure_kpa,
+        );
+    }
+
     #[test]
     fn invalid_compressor_efficiency_returns_error() {
         let input = DesignPointInput {


### PR DESCRIPTION
## What

The recuperator pressure drops were swapped in the design point calculation, causing P6 to come out lower than P1. That's physically impossible — flow goes from the recuperator hot outlet (P6) through the precooler to the compressor inlet (P1), so P6 must exceed P1.

## How

`PressureDrops::new_unchecked(top, bottom)` in `cycle.rs` had the cold-side and hot-side deltas transposed. With the baseline 2% fractional drops, the high-side drop (~6 kPa) was applied to the low-pressure stream and vice versa — enough to flip P6 below P1.

The fix swaps the arguments and adds an inline comment clarifying which side is which. A new test verifies that pressures decrease monotonically along both flow paths (P2 > P3 > P4 on the high side, P5 > P6 > P1 on the low side).
