### PR TITLE
Use MW and MPa in facade and dashboard

### DIFF
--- a/src/facade.rs
+++ b/src/facade.rs
@@ -8,8 +8,8 @@ use uom::si::{
     f64::{Power, Pressure, Ratio, ThermalConductance, ThermodynamicTemperature},
     mass_density::kilogram_per_cubic_meter,
     mass_rate::kilogram_per_second,
-    power::kilowatt,
-    pressure::kilopascal,
+    power::megawatt,
+    pressure::megapascal,
     ratio::ratio,
     specific_heat_capacity::kilojoule_per_kilogram_kelvin,
     thermal_conductance::kilowatt_per_kelvin,
@@ -35,14 +35,14 @@ pub struct DesignPointInput {
     /// Turbine inlet temperature in degrees Celsius.
     pub turbine_inlet_temp_c: f64,
 
-    /// Compressor inlet (minimum cycle) pressure in kilopascals.
-    pub compressor_inlet_pressure_kpa: f64,
+    /// Compressor inlet (minimum cycle) pressure in megapascals.
+    pub compressor_inlet_pressure_mpa: f64,
 
-    /// Compressor outlet (maximum cycle) pressure in kilopascals.
-    pub compressor_outlet_pressure_kpa: f64,
+    /// Compressor outlet (maximum cycle) pressure in megapascals.
+    pub compressor_outlet_pressure_mpa: f64,
 
-    /// Target net cycle power output in kilowatts.
-    pub net_power_kw: f64,
+    /// Target net cycle power output in megawatts.
+    pub net_power_mw: f64,
 
     // Turbomachinery
     /// Compressor isentropic efficiency as a dimensionless ratio (0–1).
@@ -81,20 +81,20 @@ pub struct DesignPointOutput {
     /// Cycle mass flow rate in kilograms per second.
     pub mass_flow_kg_per_s: f64,
 
-    /// Compressor power consumption in kilowatts.
-    pub compressor_power_kw: f64,
+    /// Compressor power consumption in megawatts.
+    pub compressor_power_mw: f64,
 
-    /// Turbine power output in kilowatts.
-    pub turbine_power_kw: f64,
+    /// Turbine power output in megawatts.
+    pub turbine_power_mw: f64,
 
-    /// Net cycle power output (turbine minus compressor) in kilowatts.
-    pub net_power_kw: f64,
+    /// Net cycle power output (turbine minus compressor) in megawatts.
+    pub net_power_mw: f64,
 
-    /// Primary heat exchanger heat addition rate in kilowatts.
-    pub heat_input_kw: f64,
+    /// Primary heat exchanger heat addition rate in megawatts.
+    pub heat_input_mw: f64,
 
-    /// Precooler heat rejection rate in kilowatts.
-    pub heat_rejection_kw: f64,
+    /// Precooler heat rejection rate in megawatts.
+    pub heat_rejection_mw: f64,
 
     /// Cycle thermal efficiency (`η = W_net / Q_in`), dimensionless.
     pub thermal_efficiency: f64,
@@ -118,8 +118,8 @@ pub struct StatePoint {
     /// Temperature in degrees Celsius.
     pub temperature_c: f64,
 
-    /// Pressure in kilopascals.
-    pub pressure_kpa: f64,
+    /// Pressure in megapascals.
+    pub pressure_mpa: f64,
 
     /// Mass density in kilograms per cubic metre.
     pub density_kg_per_m3: f64,
@@ -154,9 +154,9 @@ fn convert_input(input: &DesignPointInput) -> Result<(OperatingPoint, Config), S
     let op = OperatingPoint {
         t_comp_in: ThermodynamicTemperature::new::<degree_celsius>(input.compressor_inlet_temp_c),
         t_turb_in: ThermodynamicTemperature::new::<degree_celsius>(input.turbine_inlet_temp_c),
-        p_comp_in: Pressure::new::<kilopascal>(input.compressor_inlet_pressure_kpa),
-        p_comp_out: Pressure::new::<kilopascal>(input.compressor_outlet_pressure_kpa),
-        net_power: Power::new::<kilowatt>(input.net_power_kw),
+        p_comp_in: Pressure::new::<megapascal>(input.compressor_inlet_pressure_mpa),
+        p_comp_out: Pressure::new::<megapascal>(input.compressor_outlet_pressure_mpa),
+        net_power: Power::new::<megawatt>(input.net_power_mw),
     };
 
     let eta_comp = IsentropicEfficiency::new(input.compressor_efficiency)
@@ -209,7 +209,7 @@ fn convert_output(
 
         StatePoint {
             temperature_c: s.temperature.get::<degree_celsius>(),
-            pressure_kpa: pressure.get::<kilopascal>(),
+            pressure_mpa: pressure.get::<megapascal>(),
             density_kg_per_m3: s.density.get::<kilogram_per_cubic_meter>(),
             enthalpy_kj_per_kg: enthalpy.get::<kilojoule_per_kilogram>(),
             entropy_kj_per_kg_k: entropy.get::<kilojoule_per_kilogram_kelvin>(),
@@ -220,11 +220,11 @@ fn convert_output(
 
     DesignPointOutput {
         mass_flow_kg_per_s: solution.m_dot.get::<kilogram_per_second>(),
-        compressor_power_kw: solution.w_dot_comp.get::<kilowatt>(),
-        turbine_power_kw: solution.w_dot_turb.get::<kilowatt>(),
-        net_power_kw: w_dot_net.get::<kilowatt>(),
-        heat_input_kw: solution.q_dot_phx.get::<kilowatt>(),
-        heat_rejection_kw: solution.q_dot_pc.get::<kilowatt>(),
+        compressor_power_mw: solution.w_dot_comp.get::<megawatt>(),
+        turbine_power_mw: solution.w_dot_turb.get::<megawatt>(),
+        net_power_mw: w_dot_net.get::<megawatt>(),
+        heat_input_mw: solution.q_dot_phx.get::<megawatt>(),
+        heat_rejection_mw: solution.q_dot_pc.get::<megawatt>(),
         thermal_efficiency: solution.eta_thermal.get::<ratio>(),
         states: points,
     }
@@ -238,9 +238,9 @@ mod tests {
         DesignPointInput {
             compressor_inlet_temp_c: 50.0,
             turbine_inlet_temp_c: 500.0,
-            compressor_inlet_pressure_kpa: 100.0,
-            compressor_outlet_pressure_kpa: 300.0,
-            net_power_kw: 10_000.0,
+            compressor_inlet_pressure_mpa: 0.1,
+            compressor_outlet_pressure_mpa: 0.3,
+            net_power_mw: 10.0,
             compressor_efficiency: 0.89,
             turbine_efficiency: 0.93,
             recuperator_ua_kw_per_k: 2000.0,
@@ -260,18 +260,18 @@ mod tests {
 
         // Physical constraints.
         assert!(out.mass_flow_kg_per_s > 0.0);
-        assert!(out.turbine_power_kw > out.compressor_power_kw);
+        assert!(out.turbine_power_mw > out.compressor_power_mw);
         assert!(out.thermal_efficiency > 0.0);
         assert!(out.thermal_efficiency < 1.0);
-        assert!(out.heat_input_kw > 0.0);
-        assert!(out.heat_rejection_kw > 0.0);
+        assert!(out.heat_input_mw > 0.0);
+        assert!(out.heat_rejection_mw > 0.0);
 
         // Net power close to target.
-        let relative_error = (out.net_power_kw - 10_000.0).abs() / 10_000.0;
+        let relative_error = (out.net_power_mw - 10.0).abs() / 10.0;
         assert!(
             relative_error < 1e-6,
-            "net power {:.3} kW deviates too far from target",
-            out.net_power_kw,
+            "net power {:.6} MW deviates too far from target",
+            out.net_power_mw,
         );
     }
 
@@ -285,9 +285,9 @@ mod tests {
                 "state {i} temperature is NaN",
             );
             assert!(
-                !state.pressure_kpa.is_nan() && state.pressure_kpa > 0.0,
+                !state.pressure_mpa.is_nan() && state.pressure_mpa > 0.0,
                 "state {i} pressure is invalid: {}",
-                state.pressure_kpa,
+                state.pressure_mpa,
             );
             assert!(
                 !state.density_kg_per_m3.is_nan() && state.density_kg_per_m3 > 0.0,
@@ -314,30 +314,30 @@ mod tests {
 
         // High-pressure side: compressor outlet → recuperator cold → PHX → turbine inlet.
         assert!(
-            s2.pressure_kpa > s3.pressure_kpa,
+            s2.pressure_mpa > s3.pressure_mpa,
             "P2 ({}) must exceed P3 ({})",
-            s2.pressure_kpa,
-            s3.pressure_kpa,
+            s2.pressure_mpa,
+            s3.pressure_mpa,
         );
         assert!(
-            s3.pressure_kpa > s4.pressure_kpa,
+            s3.pressure_mpa > s4.pressure_mpa,
             "P3 ({}) must exceed P4 ({})",
-            s3.pressure_kpa,
-            s4.pressure_kpa,
+            s3.pressure_mpa,
+            s4.pressure_mpa,
         );
 
         // Low-pressure side: turbine outlet → recuperator hot → precooler → compressor inlet.
         assert!(
-            s5.pressure_kpa > s6.pressure_kpa,
+            s5.pressure_mpa > s6.pressure_mpa,
             "P5 ({}) must exceed P6 ({})",
-            s5.pressure_kpa,
-            s6.pressure_kpa,
+            s5.pressure_mpa,
+            s6.pressure_mpa,
         );
         assert!(
-            s6.pressure_kpa > s1.pressure_kpa,
+            s6.pressure_mpa > s1.pressure_mpa,
             "P6 ({}) must exceed P1 ({})",
-            s6.pressure_kpa,
-            s1.pressure_kpa,
+            s6.pressure_mpa,
+            s1.pressure_mpa,
         );
     }
 

--- a/web/app.js
+++ b/web/app.js
@@ -13,9 +13,9 @@ const STATE_LABELS = [
 const INPUT_IDS = [
   'compressor_inlet_temp_c',
   'turbine_inlet_temp_c',
-  'compressor_inlet_pressure_kpa',
-  'compressor_outlet_pressure_kpa',
-  'net_power_kw',
+  'compressor_inlet_pressure_mpa',
+  'compressor_outlet_pressure_mpa',
+  'net_power_mw',
   'compressor_efficiency_pct',
   'turbine_efficiency_pct',
   'recuperator_ua_kw_per_k',
@@ -72,12 +72,12 @@ function fmt(v, decimals = 2) {
 }
 
 function renderScalars(r) {
-  document.getElementById('r-mass-flow').textContent = fmt(r.mass_flow_kg_per_s, 2);
-  document.getElementById('r-comp-power').textContent = fmt(r.compressor_power_kw, 1);
-  document.getElementById('r-turb-power').textContent = fmt(r.turbine_power_kw, 1);
-  document.getElementById('r-net-power').textContent = fmt(r.net_power_kw, 1);
-  document.getElementById('r-heat-in').textContent = fmt(r.heat_input_kw, 1);
-  document.getElementById('r-heat-rej').textContent = fmt(r.heat_rejection_kw, 1);
+  document.getElementById('r-mass-flow').textContent = fmt(r.mass_flow_kg_per_s, 1);
+  document.getElementById('r-comp-power').textContent = fmt(r.compressor_power_mw, 2);
+  document.getElementById('r-turb-power').textContent = fmt(r.turbine_power_mw, 2);
+  document.getElementById('r-net-power').textContent = fmt(r.net_power_mw, 2);
+  document.getElementById('r-heat-in').textContent = fmt(r.heat_input_mw, 2);
+  document.getElementById('r-heat-rej').textContent = fmt(r.heat_rejection_mw, 2);
   document.getElementById('r-eta').textContent = fmt(r.thermal_efficiency * 100, 2);
 }
 
@@ -90,7 +90,7 @@ function renderStates(states) {
       <td>${i + 1}</td>
       <td>${STATE_LABELS[i]}</td>
       <td>${fmt(s.temperature_c, 1)}</td>
-      <td>${fmt(s.pressure_kpa, 1)}</td>
+      <td>${fmt(s.pressure_mpa, 4)}</td>
       <td>${fmt(s.density_kg_per_m3, 3)}</td>
       <td>${fmt(s.enthalpy_kj_per_kg, 1)}</td>
       <td>${fmt(s.entropy_kj_per_kg_k, 4)}</td>
@@ -112,10 +112,10 @@ function renderCharts(states) {
   const hsPoints = toChartPoints(states, 'entropy_kj_per_kg_k', 'enthalpy_kj_per_kg');
   const pvPoints = states.map((s, i) => ({
     x: 1 / s.density_kg_per_m3,
-    y: s.pressure_kpa,
+    y: s.pressure_mpa,
     label: String(i + 1),
   }));
-  const phPoints = toChartPoints(states, 'enthalpy_kj_per_kg', 'pressure_kpa');
+  const phPoints = toChartPoints(states, 'enthalpy_kj_per_kg', 'pressure_mpa');
 
   if (!tsChart) {
     tsChart = createCycleChart(document.getElementById('chart-ts'), {
@@ -139,7 +139,7 @@ function renderCharts(states) {
     pvChart = createCycleChart(document.getElementById('chart-pv'), {
       title: 'P–v',
       xLabel: 'v (m³/kg)',
-      yLabel: 'P (kPa)',
+      yLabel: 'P (MPa)',
     });
   }
   pvChart.update(pvPoints);
@@ -148,7 +148,7 @@ function renderCharts(states) {
     phChart = createCycleChart(document.getElementById('chart-ph'), {
       title: 'P–h',
       xLabel: 'h (kJ/kg)',
-      yLabel: 'P (kPa)',
+      yLabel: 'P (MPa)',
     });
   }
   phChart.update(phPoints);

--- a/web/index.html
+++ b/web/index.html
@@ -24,14 +24,14 @@
         <label>Turbine inlet temperature (°C)
           <input type="number" id="turbine_inlet_temp_c" value="550" step="1">
         </label>
-        <label>Compressor inlet pressure (kPa)
-          <input type="number" id="compressor_inlet_pressure_kpa" value="8000" step="10">
+        <label>Compressor inlet pressure (MPa)
+          <input type="number" id="compressor_inlet_pressure_mpa" value="8" step="0.1">
         </label>
-        <label>Compressor outlet pressure (kPa)
-          <input type="number" id="compressor_outlet_pressure_kpa" value="20000" step="10">
+        <label>Compressor outlet pressure (MPa)
+          <input type="number" id="compressor_outlet_pressure_mpa" value="20" step="0.1">
         </label>
-        <label>Net power (kW)
-          <input type="number" id="net_power_kw" value="10000" step="100">
+        <label>Net power (MW)
+          <input type="number" id="net_power_mw" value="10" step="1">
         </label>
       </fieldset>
 
@@ -89,11 +89,11 @@
           <table id="scalar-table">
             <tbody>
               <tr><td>Mass flow rate</td><td id="r-mass-flow">—</td><td>kg/s</td></tr>
-              <tr><td>Compressor power</td><td id="r-comp-power">—</td><td>kW</td></tr>
-              <tr><td>Turbine power</td><td id="r-turb-power">—</td><td>kW</td></tr>
-              <tr><td>Net power</td><td id="r-net-power">—</td><td>kW</td></tr>
-              <tr><td>Heat input</td><td id="r-heat-in">—</td><td>kW</td></tr>
-              <tr><td>Heat rejection</td><td id="r-heat-rej">—</td><td>kW</td></tr>
+              <tr><td>Compressor power</td><td id="r-comp-power">—</td><td>MW</td></tr>
+              <tr><td>Turbine power</td><td id="r-turb-power">—</td><td>MW</td></tr>
+              <tr><td>Net power</td><td id="r-net-power">—</td><td>MW</td></tr>
+              <tr><td>Heat input</td><td id="r-heat-in">—</td><td>MW</td></tr>
+              <tr><td>Heat rejection</td><td id="r-heat-rej">—</td><td>MW</td></tr>
               <tr><td>Thermal efficiency</td><td id="r-eta">—</td><td>%</td></tr>
             </tbody>
           </table>
@@ -107,7 +107,7 @@
                 <th>#</th>
                 <th>Location</th>
                 <th>T (°C)</th>
-                <th>P (kPa)</th>
+                <th>P (MPa)</th>
                 <th>ρ (kg/m³)</th>
                 <th>h (kJ/kg)</th>
                 <th>s (kJ/kg·K)</th>


### PR DESCRIPTION
## What

The dashboard now shows MW and MPa instead of kW and kPa. Fewer digits, matches what folks expect for power cycle results. Also tunes significant figures across all displayed quantities for consistency.

Closes #39.

## How

Changed the facade API itself to speak MW/MPa — `DesignPointInput` fields become `*_mpa`/`*_mw`, `DesignPointOutput` fields likewise, and `StatePoint.pressure_kpa` becomes `pressure_mpa`. This eliminates all unit conversion from the JS layer; values pass straight through.

Display precision by quantity:

- **Mass flow**: 1dp (tenths of kg/s — appropriate for hundreds of kg/s)
- **Power/heat rates**: 2dp MW
- **Efficiency**: 2dp %
- **Temperature**: 1dp °C
- **Pressure**: 4dp MPa (maintains 3 sig figs even at low-side pressures ~0.1 MPa)
- **Density**: 3dp kg/m³
- **Enthalpy**: 1dp kJ/kg
- **Entropy**: 4dp kJ/kg·K (3–4 sig figs across the range)
