### PR TITLE
Update README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,21 @@
-# Brayton Cycle Models for Supercritical CO₂
+# Brayton Cycle Models
 
-Brayton cycle models for sCO₂ power cycles, built on [Twine](https://github.com/isentropic-dev/twine-models).
+Brayton cycle models built on [Twine](https://github.com/isentropic-dev/twine-models).
+While the models work with any fluid supported by [CoolProp](https://github.com/CoolProp/CoolProp), the primary use case is supercritical CO₂ power cycles, based on [this thesis](https://github.com/isentropic-dev/brayton/blob/main/docs/dyreby_thesis.pdf).
 
 **[Try the interactive dashboard →](https://isentropic-dev.github.io/brayton/)**
 
-This project recreates the design-point and off-design sCO₂ cycle models from [this thesis](https://github.com/isentropic-dev/brayton/blob/main/docs/dyreby_thesis.pdf) and makes them available as:
+## What's here
 
-- A Rust crate
-- A browser-based interactive dashboard
-- A Python package
+Design-point solvers for the simple recuperated and recompression Brayton cycles, available as:
 
-## What's here now
-
-The simple recuperated cycle design-point model is working, with three delivery layers:
-
-- **Rust crate** — generic solver with CoolProp/RefProp support via [twine-models](https://github.com/isentropic-dev/twine-models), plus a plain-data facade for FFI consumers
+- **Rust crate** — generic cycle solver with a plain-data facade for FFI consumers
 - **Web dashboard** — interactive, runs entirely in your browser via WASM
-- **Python package** — pip installable via PyO3 with CoolProp support (PR open, PyPI publishing coming soon)
 
-## What's coming
+## What's planned
 
-This is active work — expect daily changes over the next few days.
-
-- **Real-gas thermodynamic models** — CoolProp/RefProp integration via Twine, and a Rust port of FIT, which is a table-based interpolation over Helmholtz free energy for fast, accurate, and smooth fluid property calculations
-- **Recompression cycle** design-point model
-- **Off-design models** for both simple and recompression configurations
-- **Parametric studies** in the dashboard
+- **Python package** — pip-installable via PyO3
+- **Off-design models** for both cycle configurations
 
 ## Development
 


### PR DESCRIPTION
Update README to reflect current project state:

- Title reflects fluid-generic scope (not sCO₂-specific)
- "What's here" section covers both design-point solvers and delivery layers
- "What's planned" lists Python package and off-design models
- Removes stale references to active development cadence
