### PR TITLE
Fix recuperator effectiveness for real-gas fluids

### DIFF
--- a/src/effectiveness.rs
+++ b/src/effectiveness.rs
@@ -113,12 +113,13 @@ where
     )
     .ok()?;
 
-    // When the model fails during iteration, assume positive residual —
-    // the outlet temperature is too high.
+    // When the model fails during iteration, assume negative residual —
+    // the cold outlet temperature is high enough to violate the second
+    // law, meaning we've pushed past the pinch point.
     let observer = |event: &bisection::Event<'_, _, _>| match event {
         bisection::Event::Evaluated { .. } => None,
         bisection::Event::ModelFailed { .. } | bisection::Event::ProblemFailed { .. } => {
-            Some(bisection::Action::assume_positive())
+            Some(bisection::Action::assume_negative())
         }
     };
 

--- a/src/facade/simple.rs
+++ b/src/facade/simple.rs
@@ -488,6 +488,38 @@ mod tests {
         assert!(result.unwrap_err().contains("compressor_efficiency"));
     }
 
+    /// Dashboard defaults: effectiveness must be consistent with min ΔT.
+    ///
+    /// If min ΔT is well above zero, the recuperator isn't at its
+    /// thermodynamic limit and effectiveness must be below 1.0.
+    #[test]
+    fn effectiveness_consistent_with_min_delta_t() {
+        for model in ["PerfectGas", "CoolProp"] {
+            let input = DesignPointInput {
+                model: String::from(model),
+                compressor_inlet_temp_c: 32.0,
+                compressor_inlet_pressure_mpa: 8.0,
+                compressor_outlet_pressure_mpa: 20.0,
+                turbine_inlet_temp_c: 550.0,
+                recuperator_ua_kw_per_k: 1000.0,
+                ..baseline_input()
+            };
+            let out = design_point(&input).unwrap();
+
+            let eff = out
+                .recuperator_effectiveness
+                .expect("effectiveness should converge");
+
+            // If min ΔT is significantly above zero, effectiveness must be below 1.0.
+            assert!(
+                !(out.recuperator_min_delta_t_k > 1.0 && eff >= 1.0),
+                "[{model}] effectiveness {eff} should be < 1.0 \
+                 when min ΔT is {:.1} K",
+                out.recuperator_min_delta_t_k,
+            );
+        }
+    }
+
     #[test]
     fn invalid_pressure_drop_fraction_returns_error() {
         let input = DesignPointInput {


### PR DESCRIPTION
Fix recuperator effectiveness returning 1.0 for real-gas fluids (CoolProp) even when min ΔT is well above zero.

## The bug

The bisection observer in `effectiveness::compute` assumed positive residual on model failure, telling the solver "min ΔT is still above zero, keep pushing." For real-gas fluids near the critical point, model failures at high cold outlet temperatures mean the second law has been violated — the solver should treat that as negative (past the pinch). The inverted sign collapsed the bracket toward `q_actual` instead of `q_max`, giving `q_actual / q_max ≈ 1.0`.

Visible on the dashboard with default sCO₂ conditions: effectiveness showed 1.000 while min ΔT was 7.8 K.

## The fix

One-line change: `assume_positive()` → `assume_negative()` in the bisection observer.

## Test

Added `effectiveness_consistent_with_min_delta_t` covering both PerfectGas and CoolProp. Asserts that effectiveness < 1.0 whenever min ΔT > 1 K.

With the fix, CoolProp returns effectiveness ≈ 0.97 for the dashboard defaults — consistent with the 7.8 K min ΔT.
